### PR TITLE
Feat: Enhance post filtering and data display in admin panel

### DIFF
--- a/src/components/Post/PostFilters.tsx
+++ b/src/components/Post/PostFilters.tsx
@@ -1,69 +1,95 @@
-import React from 'react';
-import { Input, Select, SelectItem } from '@heroui/react';
-import { Icon } from '@iconify/react';
+import React from "react";
+import { Input, Select, SelectItem } from "@heroui/react";
+import { Icon } from "@iconify/react";
+import type { TagResponse } from "../../store/interfaces/tagInterfaces";
+import { GetAllTags } from "../../services";
+import { useQuery } from "@tanstack/react-query";
 
 interface PostFiltersProps {
-    searchQuery: string;
-    statusFilter: string;
-    tagFilter: string;
-    onSearchChange: (value: string) => void;
-    onStatusChange: (value: string) => void;
-    onTagChange: (value: string) => void;
+  searchQuery: string;
+  statusFilter: string;
+  tagFilter: string;
+  onSearchChange: (value: string) => void;
+  onStatusChange: (value: string) => void;
+  onTagChange: (value: string) => void;
 }
 
 const PostFilters: React.FC<PostFiltersProps> = ({
-    searchQuery,
-    statusFilter,
-    tagFilter,
-    onSearchChange,
-    onStatusChange,
-    onTagChange,
+  searchQuery,
+  statusFilter,
+  tagFilter,
+  onSearchChange,
+  onStatusChange,
+  onTagChange,
 }) => {
-    return (
-        <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-3 flex-wrap">
-            <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-auto">
-                <Input
-                    placeholder="Search posts..."
-                    value={searchQuery}
-                    onValueChange={onSearchChange}
-                    startContent={<Icon icon="lucide:search" className="text-default-400" />}
-                    className="w-full sm:w-64 bg-content1 rounded-lg"
-                    variant='bordered'
-                    radius='sm'
-                />
+  const { data } = useQuery<{
+    tags: TagResponse[];
+    total: number;
+  }>({
+    queryKey: ["tags"],
+    queryFn: () => GetAllTags({}),
+  });
 
-                <Select
-                    placeholder="Filter by status"
-                    selectedKeys={[statusFilter]}
-                    className="w-full sm:w-40 bg-content1 rounded-lg"
-                    radius='sm'
-                    variant='bordered'
-                    onChange={(e) => onStatusChange(e.target.value)}
-                >
-                    <SelectItem key="all" textValue="All">All</SelectItem>
-                    <SelectItem key="approved" textValue="Approved">Approved</SelectItem>
-                    <SelectItem key="pending" textValue="Pending">Pending</SelectItem>
-                    <SelectItem key="rejected" textValue="Rejected">Rejected</SelectItem>
-                </Select>
+  return (
+    <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-3 flex-wrap">
+      <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-auto">
+        <Input
+          placeholder="Search posts..."
+          value={searchQuery}
+          onValueChange={onSearchChange}
+          startContent={
+            <Icon icon="lucide:search" className="text-default-400" />
+          }
+          isClearable
+          className="w-full sm:w-64 bg-content1 rounded-lg"
+          variant="bordered"
+          radius="sm"
+        />
 
-                <Select
-                    placeholder="Filter by tag"
-                    selectedKeys={tagFilter ? [tagFilter] : []}
-                    className="w-full sm:w-40 bg-content1 rounded-lg"
-                    radius='sm'
-                    variant='bordered' onChange={(e) => onTagChange(e.target.value)}
-                >
-                    <SelectItem key="" textValue="">All Tags</SelectItem>
-                    <SelectItem key="React" textValue="React">React</SelectItem>
-                    <SelectItem key="JavaScript" textValue="JavaScript">JavaScript</SelectItem>
-                    <SelectItem key="TypeScript" textValue="TypeScript">TypeScript</SelectItem>
-                    <SelectItem key="Node.js" textValue="Node.js">Node.js</SelectItem>
-                    <SelectItem key="CSS" textValue="CSS">CSS</SelectItem>
-                    <SelectItem key="HTML" textValue="HTML">HTML</SelectItem>
-                </Select>
-            </div>
-        </div>
-    );
+        <Select
+          placeholder="Filter by status"
+          selectedKeys={[statusFilter]}
+          className="w-full sm:w-40 bg-content1 rounded-lg"
+          radius="sm"
+          variant="bordered"
+          onChange={(e) => onStatusChange(e.target.value)}
+        >
+          <SelectItem key="all" textValue="All">
+            All
+          </SelectItem>
+          <SelectItem key="approved" textValue="Approved">
+            Approved
+          </SelectItem>
+          <SelectItem key="pending" textValue="Pending">
+            Pending
+          </SelectItem>
+          <SelectItem key="rejected" textValue="Rejected">
+            Rejected
+          </SelectItem>
+        </Select>
+
+        <Select
+          placeholder="Filter by tag"
+          selectedKeys={tagFilter ? [tagFilter] : []}
+          className="w-full sm:w-40 bg-content1 rounded-lg"
+          radius="sm"
+          variant="bordered"
+          onChange={(e) => onTagChange(e.target.value)}
+        >
+          <SelectItem key="" textValue="">
+            All Tags
+          </SelectItem>
+          <>
+            {data?.tags.map((tag: TagResponse) => (
+              <SelectItem key={tag.id} textValue={tag.name}>
+                {tag.name}
+              </SelectItem>
+            ))}
+          </>
+        </Select>
+      </div>
+    </div>
+  );
 };
 
 export default PostFilters;

--- a/src/components/Post/PostList.tsx
+++ b/src/components/Post/PostList.tsx
@@ -29,18 +29,6 @@ const PostList: React.FC<PostListProps> = ({
   totalPages,
   onPageChange,
 }) => {
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case "published":
-        return "success";
-      case "draft":
-        return "warning";
-      case "archived":
-        return "default";
-      default:
-        return "default";
-    }
-  };
 
   const formatDate = (dateString: Date) => {
     return new Date(dateString).toLocaleDateString("en-US", {
@@ -92,7 +80,7 @@ const PostList: React.FC<PostListProps> = ({
       <TableBody emptyContent={"No posts found"}>
         {posts.map((post) => (
           <TableRow key={post.id}>
-            <TableCell className="max-w-xs truncate">{post.content}</TableCell>
+            <TableCell className="max-w-xs truncate">{post.title}</TableCell>
             <TableCell>{post.author.username}</TableCell>
             <TableCell>
               {post.tags ? (

--- a/src/components/Question/QuestionFilters.tsx
+++ b/src/components/Question/QuestionFilters.tsx
@@ -49,6 +49,7 @@ const QuestionFilters: React.FC<QuestionFiltersProps> = ({
             className="w-full sm:w-64 bg-content1 rounded-lg"
             variant="bordered"
             radius="sm"
+            isClearable
           />
 
           <Select

--- a/src/pages/TagsPage.tsx
+++ b/src/pages/TagsPage.tsx
@@ -68,7 +68,7 @@ const Tags: React.FC = () => {
             tags={data?.tags || []}
             loading={isLoading}
             page={page}
-            totalPages={Math.ceil((data?.tags.length || 0) / rowsPerPage)}
+            totalPages={Math.ceil((data?.total || 0) / rowsPerPage)}
             onPageChange={handlePageChange}
             onEditTag={handleEditTag}
           />

--- a/src/services/PostServices.ts
+++ b/src/services/PostServices.ts
@@ -33,7 +33,7 @@ const ListPosts = async (
   }
 };
 const GetAllPosts = async (filters: any) => {
-  const response = await axios.get("/posts/", { params: filters });
+  const response = await axios.get("/posts/all", { params: filters });
   return response.data;
 };
 

--- a/src/store/interfaces/postInterfaces.ts
+++ b/src/store/interfaces/postInterfaces.ts
@@ -38,6 +38,7 @@ export interface PostUpdateDto {
 
 export interface PostResponse {
     id: string;
+    title:string
     content: string;
     author: UserResponse;
     tags: TagResponse[];


### PR DESCRIPTION
This commit introduces enhancements to the post filtering and data display within the admin panel, providing a more refined user experience.

- Implements tag filtering for posts:
  - Updates the `PostFilters` component to fetch and display tags dynamically from the backend, allowing administrators to filter posts by specific tags.
- Enhances post list display:
  - Updates the `PostList` component to display the post title instead of the content in the table.
- Adds clearable functionality to question filters:
  - Updates the `QuestionFilters` component to include the `isClearable` prop to the `Input` component.
- Updates GetAllPosts endpoint:
  - Updates the `GetAllPosts` endpoint in `PostServices` to `/posts/all`.
- Updates TagPage component:
  - Updates the `TagsPage` component to calculate `totalPages` based on `data?.total` instead of `data?.tags.length`.
- Adds title to PostResponse interface:
  - Adds `title` property to the `PostResponse` interface.